### PR TITLE
fix: fix build for iOS, tvOS, and watchOS

### DIFF
--- a/Sources/SwiftJSONFormatter/SwiftJSONFormatter.swift
+++ b/Sources/SwiftJSONFormatter/SwiftJSONFormatter.swift
@@ -75,7 +75,9 @@ public struct SwiftJSONFormatter {
       let decoder = JSONDecoder()
       if let data = jsonString.data(using: .utf8), let result = try? decoder.decode(String.self, from: data) {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .withoutEscapingSlashes
+        if #available(iOS 13, tvOS 13, watchOS 6, *) {
+          encoder.outputFormatting = .withoutEscapingSlashes
+        }
         if let encoded = try? encoder.encode(result), let encodedString = String(data: encoded, encoding: .utf8) {
           return encodedString
         }


### PR DESCRIPTION
Your package supports iOS 12, tvOS 12, and watchOS 5 according to [`Package.swift`](https://github.com/luin/SwiftJSONFormatter/blob/320e944bb2b54bf6946d5226b4fbb9ae907725af/Package.swift#L6-L11).

However, `withoutEscapingSlashes` requires iOS 13+, tvOS 13+, or watchOS 6+.

https://developer.apple.com/documentation/foundation/jsonserialization/writingoptions/3081260-withoutescapingslashes

So, you have two options.

1. Wrap the code using `withoutEscapingSlashes` with `if #available`
2. Bump minimum deployment targets

This pull request will resolve the issue by the option 1.