### PR TITLE
Update minimum OS requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ let package = Package(
     platforms: [
       .macOS(.v10_15),
       .iOS(.v13),
-      .tvOS(.v12),
-      .watchOS(.v5)
+      .tvOS(.v13),
+      .watchOS(.v6)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "SwiftJSONFormatter",
     platforms: [
       .macOS(.v10_15),
-      .iOS(.v12),
+      .iOS(.v13),
       .tvOS(.v12),
       .watchOS(.v5)
     ],


### PR DESCRIPTION
`JSONEncoder.OutputFormatting.withoutEscapingSlashes` has higher OS requirements than what was defined in `Package.swift`:

```swift
@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
public static let withoutEscapingSlashes: JSONEncoder.OutputFormatting
```